### PR TITLE
Implement 3‑step training workflow

### DIFF
--- a/"b/templates/\352\260\220\354\227\274\355\216\230\354\235\264\354\247\200.html"
+++ b/"b/templates/\352\260\220\354\227\274\355\216\230\354\235\264\354\247\200.html"
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>감염 안내</title></head>
+<body>
+<h3>훈련용 메시지입니다. 당신은 감염되었습니다.</h3>
+</body>
+</html>

--- a/"b/templates/\352\260\234\354\235\270\354\240\225\353\263\264\354\236\205\353\240\245\355\216\230\354\235\264\354\247\200.html"
+++ b/"b/templates/\352\260\234\354\235\270\354\240\225\353\263\264\354\236\205\353\240\245\355\216\230\354\235\264\354\247\200.html"
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>개인정보 입력</title></head>
+<body>
+<h3>개인정보를 입력해주세요 (훈련용 화면)</h3>
+<form method="post" action="/submit-info">
+<input type="hidden" name="id" value="{{ id }}" />
+이름: <input type="text" name="name"><br>
+비밀번호: <input type="password" name="pw"><br>
+<button type="submit">전송</button>
+</form>
+</body>
+</html>

--- a/server_gui.py
+++ b/server_gui.py
@@ -67,6 +67,7 @@ def set_mode(mode: int):
     else:
         step2_btn.configure(state="normal")
         step3_btn.configure(state="disabled")
+    mode_label.configure(text=f"현재 모드: {mode}단계")
     log(f"🔧 훈련 모드 설정: {mode}단계")
 
 # (row 1) 2단계 / 3단계 버튼
@@ -77,6 +78,8 @@ step3_btn = ctk.CTkButton(server_frame, text="3단계(열람/개인정보/감염
 step2_btn.grid(row=1, column=0, padx=5, pady=3)
 step3_btn.grid(row=1, column=1, padx=5, pady=3)
 step2_btn.configure(state="disabled")          # 기본 2단계
+mode_label = ctk.CTkLabel(server_frame, text="현재 모드: 2단계")
+mode_label.grid(row=2, column=0, columnspan=2, pady=(0,5))
 
 ctk.CTkLabel(app, text="──────────────────────────────────────",
              text_color="gray").pack(pady=5)
@@ -293,7 +296,8 @@ def send_emails():
         payload = {
             "csv_path":      csv_path,
             "template_name": tpl,
-            "training_mode": training_mode   # 2 or 3
+            "training_mode": training_mode,  # 2 or 3
+            "server_base":   SERVER_BASE
         }
         res = requests.post(f"{SERVER_BASE}/send-emails", json=payload)
         log(f"📤 메일 발송 완료: {res.json()}")

--- a/templates/sample_email_step2.html
+++ b/templates/sample_email_step2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body>
+<p>{{ name }}님, 보안 알림을 확인하세요.</p>
+<a href="{{ server_base | default('') }}/infect?id={{ uuid }}">알림 확인</a>
+</body>
+</html>

--- a/templates/sample_email_step3.html
+++ b/templates/sample_email_step3.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body>
+<p>{{ name }}님, 아래 링크에서 정보를 입력해주세요.</p>
+<a href="{{ server_base | default('') }}/view-info?id={{ uuid }}">정보 입력</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support 3-step mode in `main.py`
- allow GUI to switch modes and display current mode
- pass server base and training mode when sending mails
- add minimal HTML templates including personal-info step

## Testing
- `python3 -m py_compile main.py server_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_687f102ed7608321845f32e20a84bef3