### PR TITLE
Implement 3‑step training workflow

### DIFF
--- a/"b/templates/\352\260\220\354\227\274\355\216\230\354\235\264\354\247\200.html"
+++ b/"b/templates/\352\260\220\354\227\274\355\216\230\354\235\264\354\247\200.html"
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>감염 안내</title></head>
+<body>
+<h3>훈련용 메시지입니다. 당신은 감염되었습니다.</h3>
+</body>
+</html>

--- a/"b/templates/\352\260\234\354\235\270\354\240\225\353\263\264\354\236\205\353\240\245\355\216\230\354\235\264\354\247\200.html"
+++ b/"b/templates/\352\260\234\354\235\270\354\240\225\353\263\264\354\236\205\353\240\245\355\216\230\354\235\264\354\247\200.html"
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>개인정보 입력</title></head>
+<body>
+<h3>개인정보를 입력해주세요 (훈련용 화면)</h3>
+<form method="post" action="/submit-info">
+<input type="hidden" name="id" value="{{ id }}" />
+이름: <input type="text" name="name"><br>
+비밀번호: <input type="password" name="pw"><br>
+<button type="submit">전송</button>
+</form>
+</body>
+</html>

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from uuid import UUID
 from dotenv import load_dotenv
+import sys
 
 import uvicorn
 from fastapi import FastAPI, Request, Body
@@ -30,11 +31,17 @@ load_dotenv()
 
 # FastAPI 앱 초기화
 app = FastAPI()
-app.mount("/files", StaticFiles(directory="files"), name="files")
+
+# ───────── 경로 헬퍼 ─────────
+def resource_path(relative: str) -> str:
+    base = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(base, relative)
+
+app.mount("/files", StaticFiles(directory=resource_path("files")), name="files")
 
 # 템플릿 설정
-templates = Jinja2Templates(directory="templates")
-env = Environment(loader=FileSystemLoader("templates"))
+templates = Jinja2Templates(directory=resource_path("templates"))
+env = Environment(loader=FileSystemLoader(resource_path("templates")))
 
 # 현재 훈련 테이블 관리
 CURRENT_TABLE_FILE = "current_training_table.txt"
@@ -51,10 +58,85 @@ def set_current_table(table_name: str):
 def is_locked(table: str) -> bool:
     return table.endswith("_locked")
 
+async def record_click(id: UUID, request: Request):
+    table = get_current_table()
+    if not table or is_locked(table):
+        return
+    now    = datetime.now()
+    ip     = request.client.host
+    ua     = request.headers.get("user-agent", "")
+    ref    = request.headers.get("referer", "")
+    lang   = request.headers.get("accept-language", "")
+    try:
+        conn = get_connection()
+        cur  = conn.cursor()
+        cur.execute(
+            f"""
+            UPDATE {table}
+               SET clicked_at      = %s,
+                   ip_address      = %s,
+                   user_agent      = %s,
+                   referer         = %s,
+                   accept_language = %s
+             WHERE id = %s
+               AND clicked_at IS NULL
+            """,
+            (now, ip, ua, ref, lang, str(id)),
+        )
+        conn.commit()
+        cur.close()
+        conn.close()
+    except Exception as e:
+        logging.error(f"record_click error: {e}")
+
+
+async def record_infection(id: UUID, request: Request):
+    table = get_current_table()
+    if not table or is_locked(table):
+        return False
+    try:
+        conn = get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            f"""
+            INSERT INTO {table}
+                (id, ip_address, user_agent, referer, accept_language, clicked_at, infected_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (id) DO UPDATE
+              SET
+                infected_at      = EXCLUDED.infected_at,
+                clicked_at       = COALESCE(EXCLUDED.clicked_at, {table}.clicked_at),
+                ip_address       = EXCLUDED.ip_address,
+                user_agent       = EXCLUDED.user_agent,
+                referer          = EXCLUDED.referer,
+                accept_language  = EXCLUDED.accept_language
+            """,
+            (
+                str(id),
+                request.client.host,
+                request.headers.get("user-agent", ""),
+                request.headers.get("referer", ""),
+                request.headers.get("accept-language", ""),
+                datetime.now(),
+                datetime.now(),
+            ),
+        )
+        conn.commit()
+        cur.close()
+        conn.close()
+        return True
+    except Exception as e:
+        logging.error(f"record_infection error: {e}")
+        return False
+
 # JSON 바디 모델
+training_mode = 2  # 2단계 기본값
+
 class SendEmailRequest(BaseModel):
     csv_path: str
     template_name: str
+    training_mode: int = 2
+    server_base: str | None = None
 
 # 1) 훈련 시작
 @app.post("/start-training")
@@ -225,6 +307,8 @@ async def get_click_logs():
 # 5) 메일 발송 (JSON 바디 방식)
 @app.post("/send-emails")
 async def send_emails(payload: SendEmailRequest = Body(...)):
+    global training_mode
+    training_mode = payload.training_mode
     table = get_current_table()
     if not table or is_locked(table):
         return JSONResponse(status_code=400, content={"error": "활성화된 훈련 없음 또는 이미 종료됨"})
@@ -259,7 +343,12 @@ async def send_emails(payload: SendEmailRequest = Body(...)):
                 conn.close()
 
                 # 메일 전송
-                html = template.render(name=row.get("성명", ""), uuid=unique_id)
+                html = template.render(
+                    name=row.get("성명", ""),
+                    uuid=unique_id,
+                    training_mode=training_mode,
+                    server_base=payload.server_base,
+                )
                 msg = EmailMessage()
                 msg["Subject"] = "[중요] 의심스러운 로그인 시도가 차단됨"
                 msg["From"] = os.getenv("SMTP_FROM")
@@ -303,46 +392,7 @@ async def send_emails(payload: SendEmailRequest = Body(...)):
 # 6) 피싱 감염 기록
 @app.get("/infect")
 async def infect(id: UUID, request: Request):
-    table = get_current_table()
-    if not table or is_locked(table):
-        return HTMLResponse("<h3>⛔ 훈련이 종료되어 기록할 수 없습니다.</h3>")
-
-    try:
-        conn = get_connection()
-        cur = conn.cursor()
-        
-        # 이 부분을 아래로 교체
-        cur.execute(
-            f"""
-            INSERT INTO {table}
-                (id, ip_address, user_agent, referer, accept_language, clicked_at, infected_at)
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
-            ON CONFLICT (id) DO UPDATE
-              SET
-                infected_at      = EXCLUDED.infected_at,
-                clicked_at       = COALESCE(EXCLUDED.clicked_at, {table}.clicked_at),
-                ip_address       = EXCLUDED.ip_address,
-                user_agent       = EXCLUDED.user_agent,
-                referer          = EXCLUDED.referer,
-                accept_language  = EXCLUDED.accept_language
-            """,
-            (
-                str(id),
-                request.client.host,
-                request.headers.get("user-agent", ""),
-                request.headers.get("referer", ""),
-                request.headers.get("accept-language", ""),
-                datetime.now(),
-                datetime.now()
-            )
-        )
-
-        conn.commit()
-        cur.close()
-        conn.close()
-    except Exception as e:
-        logging.error(f"infect error: {e}")
-
+    await record_infection(id, request)
     return templates.TemplateResponse("감염페이지.html", {"request": request})
 
 
@@ -353,33 +403,22 @@ async def track_click(id: UUID, request: Request):
     if not table or is_locked(table):
         return HTMLResponse(status_code=204)
 
-    now    = datetime.now()
-    ip     = request.client.host
-    ua     = request.headers.get("user-agent", "")
-    ref    = request.headers.get("referer", "")
-    lang   = request.headers.get("accept-language", "")
-
-    try:
-        conn = get_connection()
-        cur  = conn.cursor()
-        cur.execute(f"""
-            UPDATE {table}
-               SET clicked_at      = %s,
-                   ip_address      = %s,
-                   user_agent      = %s,
-                   referer         = %s,
-                   accept_language = %s
-             WHERE id = %s
-               AND clicked_at IS NULL
-        """, (now, ip, ua, ref, lang, str(id)))
-        conn.commit()
-        cur.close()
-        conn.close()
-    except Exception as e:
-        logging.error(f"track_click error: {e}")
+    await record_click(id, request)
 
     # 투명 픽셀 응답
     return RedirectResponse(url="/files/1x1.png", status_code=204)
+
+# 7-1) 개인정보 입력 화면 (3단계용)
+@app.get("/view-info")
+async def view_info(id: UUID, request: Request):
+    await record_click(id, request)
+    return templates.TemplateResponse("개인정보입력페이지.html", {"request": request, "id": id})
+
+# 7-2) 개인정보 전송 후 감염 처리
+@app.post("/submit-info")
+async def submit_info(id: UUID, request: Request):
+    await record_infection(id, request)
+    return templates.TemplateResponse("감염페이지.html", {"request": request})
 
 # 8) 감염 통계 제공
 @app.get("/infect-stats")

--- a/server_gui.py
+++ b/server_gui.py
@@ -3,7 +3,7 @@ import subprocess
 import threading
 import requests
 import time
-import os, csv
+import os, csv, sys
 from jinja2 import Environment, FileSystemLoader
 from tkinter import filedialog
 from datetime import datetime
@@ -17,6 +17,11 @@ PYTHON_PATH = r"E:\phishing_trainer\venv\Scripts\python.exe"
 SERVER_HOST = "192.168.100.81"
 SERVER_PORT = 8000
 SERVER_BASE = f"http://{SERVER_HOST}:{SERVER_PORT}"
+
+# ───────── 경로 헬퍼 ─────────
+def resource_path(relative: str) -> str:
+    base = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(base, relative)
 
 # ───────── 상태 변수 ─────────
 server_process = None
@@ -33,9 +38,12 @@ app.title("Phishing Trainer 제어판")
 app.geometry("480x800")
 
 # ───────── 템플릿 로딩 ─────────
-env = Environment(loader=FileSystemLoader("templates"))
-template_files = [f for f in os.listdir("templates") if f.endswith(".html")]
-selected_template = ctk.StringVar(value=template_files[0] if template_files else "(없음)")
+template_dir = resource_path("templates")
+env = Environment(loader=FileSystemLoader(template_dir))
+template_files = [f for f in os.listdir(template_dir) if f.endswith(".html")]
+selected_template = ctk.StringVar(
+    value=template_files[0] if template_files else "(없음)"
+)
 
 # ───────── 로그창 ─────────
 log_box = ctk.CTkTextbox(app, width=440, height=200, font=("맑은 고딕", 11))
@@ -67,6 +75,7 @@ def set_mode(mode: int):
     else:
         step2_btn.configure(state="normal")
         step3_btn.configure(state="disabled")
+    mode_label.configure(text=f"현재 모드: {mode}단계")
     log(f"🔧 훈련 모드 설정: {mode}단계")
 
 # (row 1) 2단계 / 3단계 버튼
@@ -77,6 +86,8 @@ step3_btn = ctk.CTkButton(server_frame, text="3단계(열람/개인정보/감염
 step2_btn.grid(row=1, column=0, padx=5, pady=3)
 step3_btn.grid(row=1, column=1, padx=5, pady=3)
 step2_btn.configure(state="disabled")          # 기본 2단계
+mode_label = ctk.CTkLabel(server_frame, text="현재 모드: 2단계")
+mode_label.grid(row=2, column=0, columnspan=2, pady=(0,5))
 
 ctk.CTkLabel(app, text="──────────────────────────────────────",
              text_color="gray").pack(pady=5)
@@ -129,7 +140,7 @@ log_box.pack(padx=10, pady=10)
 
 # ───────── 로고 ─────────
 try:
-    logo = Image.open("logo.png").convert("RGBA").resize((160, 40))
+    logo = Image.open(resource_path("logo.png")).convert("RGBA").resize((160, 40))
     logo_img = ImageTk.PhotoImage(logo)
     logo_label = tk.Label(app, image=logo_img, bg=app.cget("bg"))
     logo_label.image = logo_img
@@ -287,13 +298,14 @@ def send_emails():
         return
     try:
         tpl = selected_template.get()
-        if not os.path.exists(os.path.join("templates", tpl)):
+        if not os.path.exists(os.path.join(template_dir, tpl)):
             log("❌ 템플릿 없음")
             return
         payload = {
             "csv_path":      csv_path,
             "template_name": tpl,
-            "training_mode": training_mode   # 2 or 3
+            "training_mode": training_mode,  # 2 or 3
+            "server_base":   SERVER_BASE
         }
         res = requests.post(f"{SERVER_BASE}/send-emails", json=payload)
         log(f"📤 메일 발송 완료: {res.json()}")

--- a/templates/sample_email_step2.html
+++ b/templates/sample_email_step2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body>
+<p>{{ name }}님, 보안 알림을 확인하세요.</p>
+<a href="{{ server_base | default('') }}/infect?id={{ uuid }}">알림 확인</a>
+</body>
+</html>

--- a/templates/sample_email_step3.html
+++ b/templates/sample_email_step3.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body>
+<p>{{ name }}님, 아래 링크에서 정보를 입력해주세요.</p>
+<a href="{{ server_base | default('') }}/view-info?id={{ uuid }}">정보 입력</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support 3-step mode in `main.py`
- allow GUI to switch modes and display current mode
- pass server base and training mode when sending mails
- add minimal HTML templates including personal-info step
- use `resource_path` helper so `server_gui.py` works when packaged

## Testing
- `python3 -m py_compile main.py server_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_687f102ed7608321845f32e20a84bef3